### PR TITLE
arduino version.txt contains extra characters which need truncating

### DIFF
--- a/Arduino/System/BoardToolchain.cmake
+++ b/Arduino/System/BoardToolchain.cmake
@@ -102,6 +102,7 @@ function (SetupBoardToolchain)
 	if (EXISTS "${ARDUINO_INSTALL_PATH}/lib/version.txt")
 		file(READ "${ARDUINO_INSTALL_PATH}/lib/version.txt" _version)
                 string(STRIP "${_version}" _version)
+		string(REGEX REPLACE "^([0-9.]+).*" "\\1" _version "${_version}")  # added to truncate "1.8.19+dfsg1-1" to "1.8.19"
 		if(_version)
 			set(_path "${ARDUINO_INSTALL_PATH}")
 			string(REPLACE "." "0" _version "${_version}")


### PR DESCRIPTION
This one line change truncates garbage from the end of the ARDUINO definition

In the arguments to g++ previously there has been a definition in the format of
-DARDUINO=10819
The contents of the file where this is read from has changed and contains non-numeric additions. 
Some esp8266 code makes the assumption that ARDUINO will be numeric.  This change removed the new extra information
The value of ARDUINO changes from '108019+dfsg1-1'  back to 108019.

 /lib/version.txt was found in /usr/share/arduino

Arduino IDE version 1.8.19

