### PR TITLE
fix: bump cmake_policy VERSION to 3.10 for CMake 4.x compatibility

### DIFF
--- a/Arduino-toolchain.cmake
+++ b/Arduino-toolchain.cmake
@@ -34,7 +34,7 @@ endif()
 cmake_policy(PUSH)
 
 # Set policy to above 3.0.0
-cmake_policy(VERSION 3.0.0)
+cmake_policy(VERSION 3.10)
 
 # Interpret if() arguments without quotes as variables/keywords
 if (NOT CMAKE_VERSION VERSION_LESS 3.1)

--- a/Arduino/Templates/Scripts/BuildRuleScript.cmake.in
+++ b/Arduino/Templates/Scripts/BuildRuleScript.cmake.in
@@ -1,6 +1,6 @@
 # Copyright (c) 2020 Arduino CMake Toolchain
 
-cmake_policy(VERSION 3.0)
+cmake_policy(VERSION 3.10)
 
 set(ARDUINO_TOOLCHAIN_DIR "@ARDUINO_TOOLCHAIN_DIR@")
 set(ARDUINO_PATTERN_NAMES 

--- a/Arduino/Templates/Scripts/LinkScript.cmake.in
+++ b/Arduino/Templates/Scripts/LinkScript.cmake.in
@@ -1,6 +1,6 @@
 # Copyright (c) 2020 Arduino CMake Toolchain
 
-cmake_policy(VERSION 3.0)
+cmake_policy(VERSION 3.10)
 
 # Generated content based on the selected board
 set(ARDUINO_TOOLCHAIN_DIR "@ARDUINO_TOOLCHAIN_DIR@")

--- a/Arduino/Templates/Scripts/ToolScript.cmake.in
+++ b/Arduino/Templates/Scripts/ToolScript.cmake.in
@@ -1,6 +1,6 @@
 # Copyright (c) 2020 Arduino CMake Toolchain
 
-cmake_policy(VERSION 3.1)
+cmake_policy(VERSION 3.10)
 
 # Generated content based on the selected board
 set(ARDUINO_TOOLCHAIN_DIR "@ARDUINO_TOOLCHAIN_DIR@")


### PR DESCRIPTION
CMake 4.x removed support for cmake_policy(VERSION) below 3.5 and warns about versions below 3.10. Update all script templates and the main toolchain file to declare VERSION 3.10.